### PR TITLE
test: add AW_OUTPUT_JUNIT flag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,10 +14,16 @@ jobs:
           cmake -S . -B build
           -DAW_ENABLE_GRAPHICS:BOOL=OFF
           -DAW_ENABLE_HUDF:BOOL=ON
+          -DAW_OUTPUT_JUNIT:BOOL=ON
       - name: Build
         run: cmake --build build
       - name: Test
         run: ctest --test-dir build -C Debug --output-on-failure
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
   ubuntu:
     runs-on: ubuntu-22.04
     steps:
@@ -29,6 +35,7 @@ jobs:
           -DAW_ENABLE_GRAPHICS:BOOL=OFF
           -DAW_ENABLE_ASSERT:BOOL=OFF
           -DAW_ENABLE_HUDF:BOOL=ON
+          -DAW_OUTPUT_JUNIT:BOOL=ON
       - name: Build
         run: cmake --build build
       - name: Test

--- a/awlib/cmake/aw-common.cmake
+++ b/awlib/cmake/aw-common.cmake
@@ -108,10 +108,16 @@ function(aw_add_test NAME)
 	set(multivalue SOURCES PARAMS)
 	cmake_parse_arguments(PARSE_ARGV 1 ARG "${options}" "${arguments}" "${multivalue}")
 
+	if (AW_OUTPUT_JUNIT)
+		set(ADDITIONAL_PARAMS)
+	else()
+		set(ADDITIONAL_PARAMS "--output-format=junit")
+	endif()
+
 	add_executable(${NAME} ${ARG_SOURCES})
 	add_test(
 		NAME ${NAME}
-		COMMAND ${NAME} ${ARG_PARAMS}
+		COMMAND ${NAME} ${ARG_PARAMS} ${ADDITIONAL_PARAMS}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 	if (ARG_NEGATIVE)

--- a/test/include/aw/test/report_impl.h
+++ b/test/include/aw/test/report_impl.h
@@ -117,6 +117,7 @@ public:
 	void end_suite() override
 	{
 		int skipped = total - succeeded - failed;
+		println("<testsuites>");
 		print("<testsuite name=\"", name, "\" tests=\"", total, "\" errors=\"0\" ");
 		println("failures=\"", failed, "\" skipped=\"", skipped, "\">");
 		for (const auto& test_case : test_cases)
@@ -138,6 +139,7 @@ public:
 			}
 		}
 		println("</testsuite>");
+		println("</testsuites>");
 
 	}
 


### PR DESCRIPTION
This is from old uncommitted changes. I *think* it was to make it work with Jenkins xUnit plugin but I can't verify that right now as I have since migrated to GitHub CI.