### PR TITLE
graphics: attempt to fix build error on win32

### DIFF
--- a/graphics/include/aw/graphics/gl/api/types.h
+++ b/graphics/include/aw/graphics/gl/api/types.h
@@ -34,10 +34,10 @@ using GLcharARB  = char;
 using GLhalfARB  = GLushort;
 using GLhalf     = GLushort;
 using GLfixed    = GLint;
-using GLintptr      = ptrdiff_t;
-using GLsizeiptr    = ptrdiff_t;
-using GLintptrARB   = ptrdiff_t;
-using GLsizeiptrARB = ptrdiff_t;
+using GLintptr      = aw::ptrdiff_t;
+using GLsizeiptr    = aw::ptrdiff_t;
+using GLintptrARB   = aw::ptrdiff_t;
+using GLsizeiptrARB = aw::ptrdiff_t;
 using GLint64       = aw::i64;
 using GLuint64      = aw::u64;
 using GLint64EXT    = aw::i64;
@@ -45,18 +45,16 @@ using GLuint64EXT   = aw::u64;
 using GLsync = struct __GLsync*;
 
 #if (AW_PLATFORM == AW_PLATFORM_WIN32)
-#define APIENTRY __stdcall
+#define AWGL_API __stdcall
 #else
-#define APIENTRY
+#define AWGL_API
 #endif
-
-#define AWGL_API APIENTRY
 
 struct _cl_context;
 struct _cl_event;
-using GLDEBUGPROC    = void (APIENTRY *)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
-using GLDEBUGPROCARB = void (APIENTRY *)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
-using GLDEBUGPROCAMD = void (APIENTRY *)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
+using GLDEBUGPROC    = void (AWGL_API *)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+using GLDEBUGPROCARB = void (AWGL_API *)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+using GLDEBUGPROCAMD = void (AWGL_API *)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);
 
 using GLhalfNV = unsigned short;
 using GLvdpauSurfaceNV = GLintptr;

--- a/graphics/include/aw/graphics/gl/loader.h
+++ b/graphics/include/aw/graphics/gl/loader.h
@@ -10,6 +10,7 @@
 #define aw_gl_loader_h
 #include <aw/types/unknown.h>
 #include <aw/config.h>
+#include <type_traits>
 namespace aw {
 namespace gl {
 
@@ -42,8 +43,9 @@ unknown_fn* get_proc_address(const char* name);
 #endif//AW_SUPPORT_PLATFORM_X11
 
 namespace gl {
-template <typename R, typename...Args>
-void get_proc(R(*& func)(Args...), char const* name)
+template <typename Function>
+	requires std::is_function_v<Function>
+void get_proc(Function*& func, char const* name)
 {
 #if AW_SUPPORT_PLATFORM_APPLE
 	using apple::get_proc_address;
@@ -52,7 +54,7 @@ void get_proc(R(*& func)(Args...), char const* name)
 #elif AW_SUPPORT_PLATFORM_X11
 	using glx::get_proc_address;
 #endif
-	func = reinterpret_cast<R(*)(Args...)>( get_proc_address(name) );
+	func = reinterpret_cast<Function*>( get_proc_address(name) );
 };
 } // namespace gl
 } // namespace aw


### PR DESCRIPTION
gl_api.c++(719): error C2672: 'aw::gl::get_proc': no matching overloaded function found

I suspect this error is due to __stdcall changing the pointer type. To fix this, I changed get_proc to accept any function pointer. The downside is that it now requires C++20.