### PR TITLE
Fix build on macOS 15 / XCode Command Line Tools 16.

### DIFF
--- a/io/include/aw/io/mmap_file.h
+++ b/io/include/aw/io/mmap_file.h
@@ -83,18 +83,18 @@ using win32::file_mapping;
 inline file_mode get_file_mode(map_perms perms)
 {
 	using mp = map_perms;
-	switch (perms) {
-	case mp::none:
-	case mp::none|mp::exec:
+	switch (static_cast<unsigned>(perms)) {
+	case static_cast<unsigned>(mp::none):
+	case static_cast<unsigned>(mp::none|mp::exec):
 		return file_mode::none;
-	case mp::read:
-	case mp::read|mp::exec:
+	case static_cast<unsigned>(mp::read):
+	case static_cast<unsigned>(mp::read|mp::exec):
 		return file_mode::read;
-	case mp::write:
+	case static_cast<unsigned>(mp::write):
 		return file_mode::write;
-	case mp::write|mp::exec:
-	case mp::rdwr:
-	case mp::rdwr|mp::exec:
+	case static_cast<unsigned>(mp::write|mp::exec):
+	case static_cast<unsigned>(mp::rdwr):
+	case static_cast<unsigned>(mp::rdwr|mp::exec):
 		return file_mode::read|file_mode::write;
 	}
 

--- a/types/include/aw/types/byte_buffer.h
+++ b/types/include/aw/types/byte_buffer.h
@@ -8,6 +8,7 @@
  */
 #ifndef aw_types_byte_buffer_h
 #define aw_types_byte_buffer_h
+#include <cstdlib>
 #include <memory>
 namespace aw {
 /**


### PR DESCRIPTION
These build failures were detected while attempting to update vcpkg's test lab, which builds awlib, to macOS 15 "Sequoia" and XCode CLT 16: https://github.com/microsoft/vcpkg/pull/41307

```console
/Users/vcpkg/Data/b/awlib/src/2024-04-06-4d0885f5ee.clean/io/include/aw/io/mmap_file.h:91:7: warning: case value not in enumerated type 'map_perms' [-Wswitch]
   91 |         case mp::read|mp::exec:
      |              ^
/Users/vcpkg/Data/b/awlib/src/2024-04-06-4d0885f5ee.clean/io/include/aw/io/mmap_file.h:95:7: warning: case value not in enumerated type 'map_perms' [-Wswitch]
   95 |         case mp::write|mp::exec:
      |              ^
/Users/vcpkg/Data/b/awlib/src/2024-04-06-4d0885f5ee.clean/io/include/aw/io/mmap_file.h:97:7: warning: case value not in enumerated type 'map_perms' [-Wswitch]
   97 |         case mp::rdwr|mp::exec:
      |              ^
3 warnings generated.
```

Fixed by casting these values to `unsigned` before going into the switch. I don't think this is particularly 'pretty' but at least it builds. A better solution in vcpkg would be to somehow make these warnings not errors, but I was less confident in being able to suppress that in ways that awlib's maintainers would find acceptable.

```
/Library/Developer/CommandLineTools/usr/bin/c++ -DAW_MODULE_PLATFORM -DAW_STATIC_BUILD -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/platform/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/awlib/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/types/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/meta/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/algorithm/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/utility/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/math/include -fPIC -g -std=c++2b -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk -fPIC -fvisibility=hidden -MD -MT platform/CMakeFiles/awplatform.dir/demangle.c++.o -MF platform/CMakeFiles/awplatform.dir/demangle.c++.o.d -o platform/CMakeFiles/awplatform.dir/demangle.c++.o -c /Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/platform/demangle.c++
In file included from /Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/platform/demangle.c++:10:
/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/types/include/aw/types/byte_buffer.h:25:75: error: no member named 'malloc' in namespace 'std'; did you mean simply 'malloc'?
   25 |         std::unique_ptr<byte_type, free_deleter> memory{ static_cast<byte_type*>(std::malloc(size)) };
      |                                                                                  ^~~~~~~~~~~
      |                                                                                  malloc
/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/include/malloc/_malloc.h:54:35: note: 'malloc' declared here
   54 | void * __sized_by_or_null(__size) malloc(size_t __size) __result_use_check __alloc_size(1) _MALLOC_TYPED(malloc_type_malloc, 1);
      |                                   ^
In file included from /Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/platform/demangle.c++:10:
/Users/vcpkg/Data/b/awlib/src/2024-04-06-b57ded9dee.clean/types/include/aw/types/byte_buffer.h:19:45: error: no type named 'free' in namespace 'std'
   19 |                 void operator()(byte_type* memory) { std::free(memory); }
      |                                                      ~~~~~^
2 errors generated.
```

Fixed by adding missing <cstdlib> for std::malloc and std::free.