### PR TITLE
Fix build errors on macOS 15.6.1.

### DIFF
--- a/types/include/aw/types/bits/variant_dispatch.h
+++ b/types/include/aw/types/bits/variant_dispatch.h
@@ -71,11 +71,11 @@ struct vh_recursive {
 		if constexpr (Length_left > 0)
 		{
 			if (index < Mid)
-				return vh_recursive<Start,Mid,Ts...>::template dispatch(index, storage, f);
+				return vh_recursive<Start,Mid,Ts...>::dispatch(index, storage, f);
 		}
 
 		if constexpr (Length_right > 1)
-			return vh_recursive<Mid+1,End,Ts...>::template dispatch(index, storage, f);
+			return vh_recursive<Mid+1,End,Ts...>::dispatch(index, storage, f);
 
 		_unreachable();
 	}

--- a/types/include/aw/types/containers/queue.h
+++ b/types/include/aw/types/containers/queue.h
@@ -96,7 +96,7 @@ protected:
 	queue_base(queue_base&& other, Allocator const& alloc) noexcept
 		: impl(alloc)
 	{
-		if (alloc == other.alloc)
+		if (alloc == static_cast<Allocator&>(other.impl))
 			impl.swap(other.impl);
 		else
 			create_storage(other.allocated_size());


### PR DESCRIPTION
Resolves:

```console
/usr/bin/c++ -DAW_STATIC_BUILD -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/meta/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/test/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/utility/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/awlib/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/algorithm/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/math/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/platform/include -fPIC -g -std=c++2b -arch arm64 -fPIE -fvisibility=hidden -MD -MT types/tests/CMakeFiles/test_types.dir/variant.c++.o -MF types/tests/CMakeFiles/test_types.dir/variant.c++.o.d -o types/tests/CMakeFiles/test_types.dir/variant.c++.o -c /Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/tests/variant.c++
In file included from /Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/tests/variant.c++:2:
In file included from /Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include/aw/types/variant.h:451:
/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include/aw/types/bits/variant_dispatch.h:74:52: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
   74 |                                 return vh_recursive<Start,Mid,Ts...>::template dispatch(index, storage, f);
      |                                                                                ^
/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include/aw/types/bits/variant_dispatch.h:78:51: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
   78 |                         return vh_recursive<Mid+1,End,Ts...>::template dispatch(index, storage, f);
      |                                                                        ^
2 errors generated.
[54/115] /usr/bin/c++ -DAW_STATIC_BUILD -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/meta/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/test/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/utility/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/awlib/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/algorithm/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/math/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/platform/include -fPIC -g -std=c++2b -arch arm64 -fPIE -fvisibility=hidden -MD -MT types/tests/CMakeFiles/test_types.dir/queue.c++.o -MF types/tests/CMakeFiles/test_types.dir/queue.c++.o.d -o types/tests/CMakeFiles/test_types.dir/queue.c++.o -c /Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/tests/queue.c++
FAILED: [code=1] types/tests/CMakeFiles/test_types.dir/queue.c++.o
/usr/bin/c++ -DAW_STATIC_BUILD -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/meta/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/test/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/utility/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/awlib/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/algorithm/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/math/include -I/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/platform/include -fPIC -g -std=c++2b -arch arm64 -fPIE -fvisibility=hidden -MD -MT types/tests/CMakeFiles/test_types.dir/queue.c++.o -MF types/tests/CMakeFiles/test_types.dir/queue.c++.o.d -o types/tests/CMakeFiles/test_types.dir/queue.c++.o -c /Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/tests/queue.c++
In file included from /Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/tests/queue.c++:2:
/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include/aw/types/containers/queue.h:99:22: error: reference to non-static member function must be called
   99 |                 if (alloc == other.alloc)
      |                              ~~~~~~^~~~~
/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include/aw/types/containers/queue.h:118:18: note: possible target for call
  118 |         allocator_type& alloc() noexcept
      |                         ^
/Users/vcpkg/Data/b/awlib/src/2024-04-06-56e6293649.clean/types/include/aw/types/containers/queue.h:123:24: note: possible target for call
  123 |         allocator_type const& alloc() const noexcept
      |                               ^
1 error generated.
```