### PR TITLE
Fix mmap execute permissions on Win32

### DIFF
--- a/awlib/include/aw/config/clang.h
+++ b/awlib/include/aw/config/clang.h
@@ -14,7 +14,7 @@
 #define AW_COMPILER_VERSION_MINOR __clang_minor__
 
 #if defined(__x86_64__) || defined(__amd64__)
-	#define AW_ARCH AW_ARCH_X86_64
+	#define AW_ARCH AW_ARCH_x86_64
 #elif defined(__i686__) || defined(_X86_)
 	#define AW_ARCH AW_ARCH_i686
 #endif

--- a/awlib/include/aw/config/gcc.h
+++ b/awlib/include/aw/config/gcc.h
@@ -5,7 +5,7 @@
 #define AW_CVER_X __GNUC__
 #define AW_CVER_Y __GNUC_MINOR__
 #if defined(__x86_64__) || defined(__amd64__)
-	#define AW_ARCH AW_ARCH_X86_64
+	#define AW_ARCH AW_ARCH_x86_64
 #elif defined(__i686__) || defined(_X86_)
 	#define AW_ARCH AW_ARCH_i686
 #endif

--- a/awlib/include/aw/config/msvc.h
+++ b/awlib/include/aw/config/msvc.h
@@ -5,7 +5,7 @@
 #define AW_CVER_X _MSC_VER
 
 #if defined(_M_X64)
-	#define AW_ARCH AW_ARCH_X86_64
+	#define AW_ARCH AW_ARCH_x86_64
 #elif defined(_M_IX86)
 	#define AW_ARCH AW_ARCH_i686
 #endif

--- a/io/include/aw/io/file_mode.h
+++ b/io/include/aw/io/file_mode.h
@@ -35,6 +35,8 @@ enum class file_mode : unsigned {
 	truncate  = 1 << 4,
 	//! Fail if file already exists
 	exclusive = 1 << 5,
+	//! Open file for execution; only meaningful when mapping it into memory
+	execute   = 1 << 6,
 
 };
 

--- a/io/include/aw/io/mmap_file.h
+++ b/io/include/aw/io/mmap_file.h
@@ -83,22 +83,30 @@ using win32::file_mapping;
 inline file_mode get_file_mode(map_perms perms)
 {
 	using mp = map_perms;
+
+	file_mode mode;
 	switch (static_cast<unsigned>(perms)) {
-	case static_cast<unsigned>(mp::none):
-	case static_cast<unsigned>(mp::none|mp::exec):
-		return file_mode::none;
 	case static_cast<unsigned>(mp::read):
 	case static_cast<unsigned>(mp::read|mp::exec):
-		return file_mode::read;
+		mode = file_mode::read;
+		break;
 	case static_cast<unsigned>(mp::write):
-		return file_mode::write;
+		mode = file_mode::write;
+		break;
 	case static_cast<unsigned>(mp::write|mp::exec):
 	case static_cast<unsigned>(mp::rdwr):
 	case static_cast<unsigned>(mp::rdwr|mp::exec):
-		return file_mode::read|file_mode::write;
+		mode = file_mode::read|file_mode::write;
+		break;
+	default:
+		// execute-only isn't a valid mapping mode
+		return file_mode::none;
 	}
 
-	return file_mode::none;
+	if (bool(perms & mp::exec))
+		mode = mode|file_mode::execute;
+
+	return mode;
 }
 
 

--- a/io/tests/mmap_file.cpp
+++ b/io/tests/mmap_file.cpp
@@ -9,6 +9,9 @@ TestFile("mmap file");
 // TODO: look into the temporary file cleanup
 
 namespace aw {
+using fm = io::file_mode;
+using mp = io::map_perms;
+
 Test(mmap_basic_read) {
 	char const filename[] { "~temp_mmap_test.bin" };
 	constexpr size_t buf_size = 0x12000;
@@ -17,8 +20,7 @@ Test(mmap_basic_read) {
 	std::fill_n(buf1, buf_size, 'a');
 	buf1[buf_size - 0x10] = 'b';
 
-	using fm = io::file_mode;
-	auto mode = fm::write|fm::create|fm::truncate;
+	const auto mode = fm::write|fm::create|fm::truncate;
 
 	Checks {
 		io::native::file file(filename, mode);
@@ -44,8 +46,7 @@ Test(mmap_view_read) {
 	std::fill_n(buf1, buf_size, 'c');
 	buf1[buf_size - 0x10] = 'd';
 
-	using fm = io::file_mode;
-	auto mode = fm::write|fm::create|fm::truncate;
+	const auto mode = fm::write|fm::create|fm::truncate;
 
 	Checks {
 		io::native::file file(filename, mode);
@@ -70,8 +71,7 @@ Test(mmap_write_back) {
 	char* buf1 = new char[buf_size];
 	std::fill_n(buf1, buf_size, 'a');
 
-	using fm = io::file_mode;
-	auto mode = fm::write|fm::create|fm::truncate;
+	const auto mode = fm::write|fm::create|fm::truncate;
 
 	Checks {
 		io::native::file file(filename, mode);
@@ -123,8 +123,7 @@ Test(mmap_invalid_fd) {
 Test(mmap_empty_file) {
 	char const filename[] { "~temp_mmap_empty_test.bin" };
 
-	using fm = io::file_mode;
-	auto mode = fm::write|fm::create|fm::truncate;
+	const auto mode = fm::write|fm::create|fm::truncate;
 
 	Checks {
 		io::native::file file(filename, mode);
@@ -151,5 +150,39 @@ Test(mmap_blkdevide)
 		TestAssert(!ec);
 	}
 }
+#endif
+
+#if (AW_ARCH == AW_ARCH_x86_64) || (AW_ARCH == AW_ARCH_i686)
+Test(mmap_execute) {
+	char const filename[] { "~temp_mmap_exec_test.bin" };
+
+	char const code[] = {
+		'\xb8', '\x2a', '\x00', '\x00', '\x00', // mov eax, 42
+		'\xc3'                                  // ret
+	};
+
+	const auto mode = fm::write|fm::create|fm::truncate;
+
+	Checks {
+		io::native::file file(filename, mode);
+		auto ret = file.write(code, sizeof(code));
+		TestAssert(ret > 0);
+	}
+
+	Checks {
+		std::error_code ec;
+		io::mmap_file file(filename, ec, mp::read|mp::exec);
+		TestAssert(!ec);
+		TestAssert(file.is_open());
+
+		if (file.is_open()) {
+			auto func = reinterpret_cast<int(*)()>(file.data());
+			// will segfault with wrong perms
+			TestEqual(func(), 42);
+		}
+	}
+
+	fs::remove( filename );
+};
 #endif
 } // namespace aw

--- a/io/win32/file.c++
+++ b/io/win32/file.c++
@@ -20,6 +20,8 @@ int get_access( file_mode mode )
 		access |= GENERIC_READ;
 	if (bool(mode & fm::write))
 		access |= GENERIC_WRITE;
+	if (bool(mode & fm::execute))
+		access |= GENERIC_EXECUTE;
 	return access;
 }
 

--- a/io/win32/mmap.c++
+++ b/io/win32/mmap.c++
@@ -17,6 +17,7 @@ unsigned get_protection( map_perms perms )
 {
 	using mp = map_perms;
 	switch (perms) {
+	default:
 	case mp::none:
 		return 0;
 	case mp::read:
@@ -35,19 +36,22 @@ unsigned get_protection( map_perms perms )
 unsigned get_access( map_perms perms )
 {
 	using mp = map_perms;
-	switch (perms) {
-	case mp::none:
-		return 0;
-	case mp::read:
-	case mp::read|mp::execute:
-		return FILE_MAP_READ;
-	case mp::write:
-	case mp::write|mp::execute:
-		return FILE_MAP_WRITE;
-	case mp::rdwr:
-	case mp::rdwr|mp::execute:
-		return FILE_MAP_ALL_ACCESS;
-	}
+
+	unsigned result = 0;
+
+	if (!(perms & mp::rdwr)) // MapViewOfFile doesn't have execute-only mode
+		return result;
+
+	if (bool(perms & mp::write))
+		result |= FILE_MAP_WRITE;
+	if (bool(perms & mp::read))
+		result |= FILE_MAP_READ;
+	if (bool(perms & mp::execute))
+		result |= FILE_MAP_EXECUTE;
+
+	// TODO: add a flag for FILE_MAP_ALL_ACCESS ?
+
+	return result;
 }
 } // namespace
 


### PR DESCRIPTION
I noticed that win32 code lacks any support for execute permissions due to MSDN misreading.
Adding test to reproduce the issue.