### PR TITLE
ci: add gcc/clang/no-builtins job matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         run: ctest --test-dir build -C Debug --output-on-failure
   ubuntu:
     name: ubuntu (${{ matrix.cc }}, no-builtins=${{ matrix.no_builtins }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,16 +33,29 @@ jobs:
       - name: Test
         run: ctest --test-dir build -C Debug --output-on-failure
   ubuntu:
+    name: ubuntu (${{ matrix.cc }}, no-builtins=${{ matrix.no_builtins }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { cc: gcc,   cxx: g++,     no_builtins: "OFF" }
+          - { cc: clang, cxx: clang++, no_builtins: "OFF" }
+          # The fallbacks are plain C++ with no per-compiler paths, so one
+          # job is enough to cover them.
+          - { cc: gcc,   cxx: g++,     no_builtins: "ON" }
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Configure
         run: >
           cmake -S . -B build
+          -DCMAKE_C_COMPILER=${{ matrix.cc }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
           -DAW_ENABLE_GRAPHICS:BOOL=OFF
           -DAW_ENABLE_ASSERT:BOOL=OFF
           -DAW_ENABLE_HUDF:BOOL=ON
+          -DAW_NO_BUILTINS:BOOL=${{ matrix.no_builtins }}
       - name: Build
         run: cmake --build build
       - name: Test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,28 +4,21 @@ on:
   push:
 
 jobs:
-  windows-x86:
+  windows:
+    name: windows-${{ matrix.name }}
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: x86, platform: Win32 }
+          - { name: x64, platform: x64 }
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Configure
         run: >
-          cmake -S . -B build -A Win32
-          -DAW_ENABLE_GRAPHICS:BOOL=OFF
-          -DAW_ENABLE_HUDF:BOOL=ON
-      - name: Build
-        run: cmake --build build
-      - name: Test
-        run: ctest --test-dir build -C Debug --output-on-failure
-  windows-x64:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Configure
-        run: >
-          cmake -S . -B build -A x64
+          cmake -S . -B build -A ${{ matrix.platform }}
           -DAW_ENABLE_GRAPHICS:BOOL=OFF
           -DAW_ENABLE_HUDF:BOOL=ON
       - name: Build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,3 +53,19 @@ jobs:
         run: cmake --build build
       - name: Test
         run: ctest --test-dir build --output-on-failure
+  macos:
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DAW_ENABLE_GRAPHICS:BOOL=OFF
+          -DAW_ENABLE_ASSERT:BOOL=OFF
+          -DAW_ENABLE_HUDF:BOOL=ON
+          -DAW_NO_BUILTINS:BOOL=OFF
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/types/include/aw/types/tmpflag.h
+++ b/types/include/aw/types/tmpflag.h
@@ -13,6 +13,9 @@ namespace aw {
 /*!
  * Temporal flag — a flag that is set only for specified
  * period of time (i.e. resets itself after duration passes).
+ *
+ * A typical use-case for this is to implement and action on
+ * double key press.
  */
 struct tmpflag {
 	using clock_type = std::chrono::steady_clock;

--- a/types/tests/tmpflag.c++
+++ b/types/tests/tmpflag.c++
@@ -11,19 +11,19 @@ Test(tmpflag) {
 	Checks {
 		TestAssert( !f );
 
-		f.set( 500ms );
+		f.set( 10ms );
 
 		TestAssert( !!f );
 
-		std::this_thread::sleep_for( 500ms );
+		std::this_thread::sleep_for( 10ms );
 
 		TestAssert( !f );
 
-		f.set( 250ms );
+		f.set( 1min );
 
 		TestAssert( !!f );
 
-		std::this_thread::sleep_for( 200ms );
+		std::this_thread::sleep_for( 10ms );
 
 		TestAssert( f == true );
 
@@ -31,5 +31,18 @@ Test(tmpflag) {
 
 		TestAssert( f == false );
 	}
+}
+
+Test(tmpflag_reset) {
+	using namespace std::chrono_literals;
+	tmpflag f;
+
+	f.set( 1h );
+
+	TestAssert( !!f );
+
+	f.reset();
+
+	TestAssert( !f );
 }
 } // namespace aw


### PR DESCRIPTION
There's a gap in CI where only one path (builtins/no-builtins) is tested, so these implementations can diverge.
And because different compilers might have slight different in builtin behavior, it's worth adding clang here (but it's worth adding it for other reasons as well).